### PR TITLE
docs: add central README for OctoAcme project management docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,37 @@
+# OctoAcme Project Management Docs
+
+Welcome to the central documentation hub for OctoAcme's project management processes. This README is the main entry point for contributors and team members to quickly understand, find, and use our process guides.
+
+Quick summary
+- Customer-first and iterative delivery
+- Clear ownership and role definitions (PM, PdM, Developers, QA)
+- Work broken into shippable increments with defined acceptance criteria
+- Regular cadence for planning, execution, demos, and retrospectives
+- Continuous improvement driven by retrospectives and tracked action items
+- Risks, dependencies and stakeholder communication are tracked and escalated explicitly
+
+Core process documents
+- Project Management Overview — short intro to our approach, roles, and artifacts
+  - File: ./octoacme-project-management-overview.md
+- Project Initiation — how to validate, align stakeholders, and create a lightweight plan
+  - File: ./octoacme-project-initiation.md
+- Project Planning — turning approved initiatives into a backlog, estimates, and release plan
+  - File: ./octoacme-project-planning.md
+- Execution & Tracking — day-to-day rhythms, PR/CI expectations, and tracking checklists
+  - File: ./octoacme-execution-and-tracking.md
+- Risk Management & Communication — maintaining a risk register and communication templates
+  - File: ./octoacme-risks-and-communication.md
+- Release & Deployment — release types, checklist, and rollback playbooks
+  - File: ./octoacme-release-and-deployment.md
+- Retrospective & Continuous Improvement — running retros, tracking action items and impact
+  - File: ./octoacme-retrospective-and-continuous-improvement.md
+- Roles & Personas — role summaries and responsibilities used across the docs
+  - File: ./octoacme-roles-and-personas.md
+
+How to use this hub
+- Browse the documents above to find process details, checklists, and templates.
+- Use the issue template (.github/ISSUE_TEMPLATE/add-update-content-to-process-docs.yml) for proposing updates or new docs.
+- If you propose a change, reference the relevant doc and provide a short rationale and suggested content.
+
+Maintainers & contact
+- If you have questions or want this README updated, open an issue or use the process doc issue template. For urgent process escalations, contact the Project Manager or Product Lead noted in the relevant project docs.


### PR DESCRIPTION
Summary: Adds docs/README.md as the central entry point for OctoAcme project management docs.

Related: #2